### PR TITLE
Add "." or "./" to reference current note's folder

### DIFF
--- a/src/get-imgs-list.ts
+++ b/src/get-imgs-list.ts
@@ -7,7 +7,11 @@ const getImagesList = (
     settings: {[key: string]: any}
   ) => {
   // retrieve a list of the files
-  const folder = app.vault.getAbstractFileByPath(settings.path)
+  const parentFolderPath = app.workspace.getActiveFile().parent.path
+  const folderPath = settings.path === '.' 
+    ? parentFolderPath 
+    : settings.path.replace('./', `${parentFolderPath}/`)
+  const folder = app.vault.getAbstractFileByPath(folderPath)
 
   let files
   if (folder instanceof TFolder) { files = folder.children }


### PR DESCRIPTION
I found the plugin to be very useful for having a "preview" file in my "gallery" folders and exploring the images without leaving Obsidian.

Problem: I wasn't able to reuse the file as much because I had to modify the path in every instance, which quickly became a rather tedious chore.

Proposed solution: using "." to reference the path where the current note is located.

Additionally, since it was a very similar change, I added support for "./" to access subfolders of the current note's location.