### PR TITLE
Added recursive image search to image gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@
 Obsidian Image Gallery is a zero setup masonry image gallery for [Obsidian](https://obsidian.md/).
 
 **Table of Contents**
-- [Requirements](#requirements)
-- [Usage](#usage)
-- [Settings](#settings)
-- [Notes](#notes)
-- [Examples](#examples)
-- [Acknowledgments](#acknowledgments)
-- [License](#license)
-- [Contacts](#contacts)
+- [Obsidian Image Gallery](#obsidian-image-gallery)
+  - [Requirements](#requirements)
+  - [Installation](#installation)
+  - [Usage](#usage)
+  - [Settings](#settings)
+  - [Notes:](#notes)
+  - [Examples:](#examples)
+  - [Changelog](#changelog)
+  - [Acknowledgments](#acknowledgments)
+  - [License](#license)
+  - [Contacts](#contacts)
 
 ## Requirements
 
@@ -56,14 +59,15 @@ In *[Live Preview](https://help.obsidian.md/Live+preview+update)* mode, the gall
 
 Settings can be customized in any order, in `yaml` syntax. Optional properties default to the values outlined in the tables below:
 
-| Option   | Default      | Alternatives    | Required | Description                            |
-| -------- | ------------ | --------------- | -------- | -------------------------------------- |
-| `path`   | -            | -               | Yes      | Path relative to the root of the vault |
-| `type`   | `horizontal` | `vertical`      | No       | Type of masonry                        |
-| `gutter` | `8`          | (any number)    | No       | Spacing in px between the images       |
-| `radius` | `0`          | (any number)    | No       | Border radius in px of the images      |
-| `sortby` | `ctime`      | `mtime`, `name` | No       | Sort images by                         |
-| `sort`   | `desc`       | `asc`           | No       | Order of sorting                       |
+| Option      | Default      | Alternatives    | Required | Description                            |
+| ----------- | ------------ | --------------- | -------- | -------------------------------------- |
+| `path`      | -            | -               | Yes      | Path relative to the root of the vault |
+| `type`      | `horizontal` | `vertical`      | No       | Type of masonry                        |
+| `gutter`    | `8`          | (any number)    | No       | Spacing in px between the images       |
+| `radius`    | `0`          | (any number)    | No       | Border radius in px of the images      |
+| `sortby`    | `ctime`      | `mtime`, `name` | No       | Sort images by                         |
+| `sort`      | `desc`       | `asc`           | No       | Order of sorting                       |
+| `recursive` | `false`      | `true`          | No       | Adds images within subfolder of path   |
 
 Options applicable only for `type=horizontal`:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-image-gallery",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-image-gallery",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/js-yaml": "^4.0.5",

--- a/src/get-imgs-list.ts
+++ b/src/get-imgs-list.ts
@@ -4,7 +4,7 @@ import renderError from './render-error'
 const getImagesList = (
     app: App,
     container: HTMLElement,
-    settings: {[key: string]: any}
+    settings: {[key: string]: any},
   ) => {
   // retrieve a list of the files
   const folder = app.vault.getAbstractFileByPath(settings.path)
@@ -19,9 +19,19 @@ const getImagesList = (
 
   // filter the list of files to make sure we're dealing with images only
   const validExtensions = ["jpeg", "jpg", "gif", "png", "webp", "tiff", "tif"]
-  const images = files.filter(file => {
+  let images = files.filter(file => {
     if (file instanceof TFile && validExtensions.includes(file.extension)) return file
   })
+
+  // check if we should recursively look for files in sub-folders, if so find all files.
+  if (settings.recursive) {
+    files.forEach(f => {
+      if (f instanceof TFolder && f.path != settings.path) {
+        settings.path = f.path;
+        images = images.concat(getImagesListHelper(app, container, settings, f.path))
+      }
+    })
+  }
 
   // sort the list by name, mtime, or ctime
   const orderedImages = images.sort((a: any, b: any) => {
@@ -34,13 +44,45 @@ const getImagesList = (
   const sortedImages = settings.sort === 'asc' ? orderedImages : orderedImages.reverse()
 
   // return an array of objects
-  return sortedImages.map(file => {
-    return {
-      name: file.name,
-      folder: file.parent.path,
-      uri: app.vault.adapter.getResourcePath(file.path)
-    }
+  return sortedImages.map(file => { return {
+    name: file.name,
+    folder: file.parent.path,
+    uri: app.vault.adapter.getResourcePath(file.path)
+    }})
+}
+
+const getImagesListHelper = (
+  app: App,
+  container: HTMLElement,
+  settings: {[key: string]: any},
+  path: string
+) => {
+
+  // retrieve a list of the files
+  const folder = app.vault.getAbstractFileByPath(path)
+
+  let files
+  if (folder instanceof TFolder) { files = folder.children }
+  else {
+    return []
+  }
+
+  // filter the list of files to make sure we're dealing with images only
+  const validExtensions = ["jpeg", "jpg", "gif", "png", "webp", "tiff", "tif"]
+  let images = files.filter(file => {
+    if (file instanceof TFile && validExtensions.includes(file.extension)) return file
   })
+
+  // check if we should recursively look for files in sub-folders, if so find all files.
+  if (settings.recursive) {
+    files.forEach(f => {
+      if (f instanceof TFolder && f.path != path) {
+        images = images.concat(getImagesListHelper(app, container, settings, f.path))
+      }
+    })
+  }
+
+  return images
 }
 
 export default getImagesList

--- a/src/get-settings.ts
+++ b/src/get-settings.ts
@@ -29,6 +29,7 @@ const getSettings = (src: string, container: HTMLElement) => {
     mobile: undefined as number,
     columns: undefined as number,
     height: undefined as number,
+    recursive: undefined as boolean,
   }
 
   settings.path = normalizePath(settingsSrc.path)
@@ -37,6 +38,7 @@ const getSettings = (src: string, container: HTMLElement) => {
   settings.gutter = settingsSrc.gutter ?? 8
   settings.sortby = settingsSrc.sortby ?? 'ctime'
   settings.sort = settingsSrc.sort ?? 'desc'
+  settings.recursive = settingsSrc.recursive ?? false
 
   // settings for vertical mansory only
   settings.mobile = settingsSrc.mobile ?? 1


### PR DESCRIPTION
Resolves Issue #20 in adding recursive search for image gallery.

To test, you can do the following:

1. `git clone https://github.com/johnsbuck/obsidian-image-gallery.git`
2. `git checkout issue-20`
3. `npm run build`
4. Copy `main.js` from dev folder to `<vault_folder>/.obsidian/plugins/obsidian-image-gallery`
5. Test with example query below:

<pre>
```image-gallery
path: path/to/img/super/folder
type: vertical
recursive: true
```
</pre>
