### PR TITLE
A universal way to add images from folders or individual files to gallery - `targets`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Obsidian Image Gallery is a zero setup masonry image gallery for [Obsidian](http
 ## Requirements
 
 - [Obsidian](https://obsidian.md/) `(ver >= 1.1.8)`
-- A folder(s) of local images located somewhere in your vault
+- A folder(s) of local images and just image(s) located somewhere in your vault
 
 ## Installation
 
@@ -24,12 +24,12 @@ Obsidian Image Gallery can be installed from within Obsidian, as for [every othe
 
 ## Usage
 
-To create a dynamic gallery, add one of the following code blocks to a note (make sure to customize the path!):
+To create a dynamic gallery, add one of the following code blocks to a note (make sure to customize the paths in `targets`!):
 
 For a horizontal masonry:
 ````
 ```img-gallery
-path: Attachments/Folder
+targets: Attachments/Folder
 type: horizontal
 ```
 ````
@@ -37,8 +37,18 @@ type: horizontal
 For a vertical masonry:
 ````
 ```img-gallery
-path: Attachments/Folder
+targets: Attachments/Folder
 type: vertical
+```
+````
+
+For a multiple files:
+````
+```img-gallery
+targets:
+- Attachments/Folder
+- Attachments/Folder2/pony.png
+type: horizontal
 ```
 ````
 
@@ -56,14 +66,15 @@ In *[Live Preview](https://help.obsidian.md/Live+preview+update)* mode, the gall
 
 Settings can be customized in any order, in `yaml` syntax. Optional properties default to the values outlined in the tables below:
 
-| Option   | Default      | Alternatives    | Required | Description                            |
-| -------- | ------------ | --------------- | -------- | -------------------------------------- |
-| `path`   | -            | -               | Yes      | Path relative to the root of the vault |
-| `type`   | `horizontal` | `vertical`      | No       | Type of masonry                        |
-| `gutter` | `8`          | (any number)    | No       | Spacing in px between the images       |
-| `radius` | `0`          | (any number)    | No       | Border radius in px of the images      |
-| `sortby` | `ctime`      | `mtime`, `name` | No       | Sort images by                         |
-| `sort`   | `desc`       | `asc`           | No       | Order of sorting                       |
+| Option    | Default      | Alternatives    | Required        | Description                                                |
+| --------- | ------------ | --------------- | --------------- | ---------------------------------------------------------- |
+| `targets` | -            | -               | Yes             | Paths to folders and images relative to root of the vaults |
+| `path`    | -            | -               | No (deprecated) | Path relative to the root of the vault                     |
+| `type`    | `horizontal` | `vertical`      | No              | Type of masonry                                            |
+| `gutter`  | `8`          | (any number)    | No              | Spacing in px between the images                           |
+| `radius`  | `0`          | (any number)    | No              | Border radius in px of the images                          |
+| `sortby`  | `ctime`      | `mtime`, `name` | No              | Sort images by                                             |
+| `sort`    | `desc`       | `asc`           | No              | Order of sorting                                           |
 
 Options applicable only for `type=horizontal`:
 
@@ -80,7 +91,7 @@ Options applicable only for `type=vertical`:
 
 
 ## Notes:
-- For `path` there is no need to specify the name of the vault
+- For `targets` there is no need to specify the name of the vault.
 - As mentioned in the [Requirements](#requirements) section, only local images are accepted. This plugin was designed with a specific use case in mind: create a gallery from a folder of images with as little setup as possible.
 - Make sure the images to embed have a reasonable size: generating a masonry with 60 4k photos will most likely slow down the app to a crawl!
 

--- a/src/get-imgs-list.ts
+++ b/src/get-imgs-list.ts
@@ -1,4 +1,4 @@
-import { App, TFolder, TFile } from 'obsidian'
+import { App, TFolder, TFile, TAbstractFile } from 'obsidian'
 import renderError from './render-error'
 
 const getImagesList = (
@@ -7,12 +7,36 @@ const getImagesList = (
     settings: {[key: string]: any}
   ) => {
   // retrieve a list of the files
-  const folder = app.vault.getAbstractFileByPath(settings.path)
 
-  let files
-  if (folder instanceof TFolder) { files = folder.children }
-  else {
-    const error = 'The folder doesn\'t exist, or it\'s empty!'
+  let files: TAbstractFile[] = []
+
+  settings.targets.forEach((target: string) => {
+    const file = app.vault.getAbstractFileByPath(target)
+    if (file instanceof TFolder) {
+      files.push(...file.children)
+    }
+    else if (file instanceof TFile) {
+      files.push(file)
+    }
+    else {
+      console.warn('The target ' + target + ' doesn\'t exist!')
+    }
+  });
+
+  // depricated field
+  if (settings.path !== undefined) {
+    const folder = app.vault.getAbstractFileByPath(settings.path)
+    if (folder instanceof TFolder) {
+      files.push(...folder.children)
+    }
+    else {
+      console.warn('The folder doesn\'t exist, or it\'s empty!')
+    }
+  }
+
+
+  if (files.length === 0) {
+    const error = 'The file list is empty!'
     renderError(container, error)
     throw new Error(error)
   }

--- a/src/get-settings.ts
+++ b/src/get-settings.ts
@@ -12,8 +12,8 @@ const getSettings = (src: string, container: HTMLElement) => {
     throw new Error(error)
   }
 
-  if (!settingsSrc.path) {
-    const error = 'Please specify a path!'
+  if (!settingsSrc.path && !settingsSrc.targets) {
+    const error = 'Please specify a path or targets!'
     renderError(container, error)
     throw new Error(error)
   }
@@ -21,6 +21,7 @@ const getSettings = (src: string, container: HTMLElement) => {
   // store settings, normalize and set sensible defaults
   const settings = {
     path: undefined as string,
+    targets: [] as string[],
     type: undefined as string,
     radius: undefined as number,
     gutter: undefined as string,
@@ -31,7 +32,22 @@ const getSettings = (src: string, container: HTMLElement) => {
     height: undefined as number,
   }
 
-  settings.path = normalizePath(settingsSrc.path)
+  try {
+    settings.path = settings.path ? normalizePath(settingsSrc.path) : undefined
+
+    if (!settingsSrc.targets || settingsSrc.targets.length === 0) settings.targets = []
+    else settings.targets = settingsSrc.targets.map((target: string) => {
+      if (target)
+        return normalizePath(target)
+      else
+        console.warn('Target is empty!')
+    });
+  }
+  catch (error) {
+    renderError(container, error)
+    throw new Error(error)
+  }
+
   settings.type = settingsSrc.type ?? 'horizontal'
   settings.radius = settingsSrc.radius ?? 0
   settings.gutter = settingsSrc.gutter ?? 8

--- a/src/get-settings.ts
+++ b/src/get-settings.ts
@@ -33,7 +33,7 @@ const getSettings = (src: string, container: HTMLElement) => {
   }
 
   try {
-    settings.path = settings.path ? normalizePath(settingsSrc.path) : undefined
+    settings.path = settingsSrc.path ? normalizePath(settingsSrc.path) : undefined
 
     if (!settingsSrc.targets || settingsSrc.targets.length === 0) settings.targets = []
     else settings.targets = settingsSrc.targets.map((target: string) => {


### PR DESCRIPTION
## What does this PR?
When I started using the plugin, adding only directories with images seemed inconvenient to me. Because I required the ability to add individual files also. In my revision, I added this feature, made this method universal (you can specify both directories and individual files) and slightly improved other points.

## Change list
- Added the `targets` field as a universal way to include images from entire folders or specific files. Using this field, you can include multiples targets (one and more).

For example:
````
```img-gallery
targets:
- Science\Bio\_img\plants\
- Science\Physics\_img\light\
- urban\_img\landscaping0.jpg
- urban\_img\landscaping1.jpg
type: horizontal
```
````

- Backward compatibility with the `path` field has been preserved. But now it is not “required” and marked as “deprecated” because `targets` is the preferred method because of its versatility. Field `path` can be used together with the field `targets`, images from these sources will be merged in the gallery.
- Improved warnings and error messages. If `path` or any target from `targets` is incorrect, a warning about it will be entered in the console. If the resulting list of files turns out to be empty, a corresponding error will be output to the container.
- Updated README according to the relevant changes.

## Conclusion
If you have any feedback: code additions, suggestions, comments, questions. I will be glad! :)