### PR TITLE
New settings options (file list, regex filter); enabled relative paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,13 @@ An additional note about the orientation of the masonry vs. the distribution of 
 
 `1.1.2`
   - Changed: "path" setting can now be relative to the current file's directory (prefix with "./").
-  - New: "images" setting. Accepts a YAML list of filenames. If this value is provided, only these files will be displayed from the directory. When provided. Overrides any specified sorting order, in favor of the order of the list.
-  - New: "regex" setting. Accepts a YAML list of regular expression strings. If this value is provided, only filenames that match AT LEAST ONE of the expressions will be displayed.
+
+  - New: "images" setting. Accepts a YAML list of filenames. If this value is provided, only these 
+         files will be displayed from the directory. When provided. Overrides any specified sorting 
+         order, in favor of the order of the list.
+
+  - New: "regex" setting. Accepts a YAML list of regular expression strings. If this value is provided, 
+         only filenames that match AT LEAST ONE of the expressions will be displayed.
 
 `1.1.1`
   - fixed bug for the "open image in new tab" feature

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ An additional note about the orientation of the masonry vs. the distribution of 
 
 `1.1.2`
   - Changed: "path" setting can now be relative to the current file's directory. To do this, prefix 
-             the path with "./".
+             the path with "./" or "../".
 
   - New: "images" setting. Accepts a YAML list of filenames. If this value is provided, only these 
          files will be displayed from the directory. When provided. Overrides any specified sorting 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ An additional note about the orientation of the masonry vs. the distribution of 
 ## Changelog
 
 `1.1.2`
-  - Changed: "path" setting can now be relative to the current file's directory (prefix with "./").
+  - Changed: "path" setting can now be relative to the current file's directory. To do this, prefix 
+             the path with "./".
 
   - New: "images" setting. Accepts a YAML list of filenames. If this value is provided, only these 
          files will be displayed from the directory. When provided. Overrides any specified sorting 

--- a/README.md
+++ b/README.md
@@ -56,14 +56,16 @@ In *[Live Preview](https://help.obsidian.md/Live+preview+update)* mode, the gall
 
 Settings can be customized in any order, in `yaml` syntax. Optional properties default to the values outlined in the tables below:
 
-| Option   | Default      | Alternatives    | Required | Description                            |
-| -------- | ------------ | --------------- | -------- | -------------------------------------- |
-| `path`   | -            | -               | Yes      | Path relative to the root of the vault |
-| `type`   | `horizontal` | `vertical`      | No       | Type of masonry                        |
-| `gutter` | `8`          | (any number)    | No       | Spacing in px between the images       |
-| `radius` | `0`          | (any number)    | No       | Border radius in px of the images      |
-| `sortby` | `ctime`      | `mtime`, `name` | No       | Sort images by                         |
-| `sort`   | `desc`       | `asc`           | No       | Order of sorting                       |
+| Option   | Default      | Alternatives                 | Required | Description                                               |
+| -------- | ------------ | ---------------------------- | -------- | --------------------------------------------------------- |
+| `path`   | -            | -                            | Yes      | Path relative to the root of the vault                    |
+| `type`   | `horizontal` | `vertical`                   | No       | Type of masonry                                           |
+| `gutter` | `8`          | (any number)                 | No       | Spacing in px between the images                          |
+| `radius` | `0`          | (any number)                 | No       | Border radius in px of the images                         |
+| `sortby` | `ctime`      | `mtime`, `name`              | No       | Sort images by                                            |
+| `sort`   | `desc`       | `asc`                        | No       | Order of sorting                                          |
+| `images` | `[]`         | YAML list of image filenames | No       | Specific image files to use (instead of entire directory) |
+| `regex`  | `[]`         | YAML list of regex strings   | No       | Regular expressions to filter image files                 |
 
 Options applicable only for `type=horizontal`:
 
@@ -90,6 +92,11 @@ An additional note about the orientation of the masonry vs. the distribution of 
 ![Obsidian Image Gallery - Examples](assets/obsidian-image-gallery-examples.jpg)
 
 ## Changelog
+
+`1.1.2`
+  - Changed: "path" setting can now be relative to the current file's directory (prefix with "./").
+  - New: "images" setting. Accepts a YAML list of filenames. If this value is provided, only these files will be displayed from the directory. When provided. Overrides any specified sorting order, in favor of the order of the list.
+  - New: "regex" setting. Accepts a YAML list of regular expression strings. If this value is provided, only filenames that match AT LEAST ONE of the expressions will be displayed.
 
 `1.1.1`
   - fixed bug for the "open image in new tab" feature

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-image-gallery",
   "name": "Image Gallery",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "minAppVersion": "1.1.8",
   "description": "A zero setup masonry image gallery for Obsidian",
   "author": "Luca Orio",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-image-gallery",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-image-gallery",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/js-yaml": "^4.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-image-gallery",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-image-gallery",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/js-yaml": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-image-gallery",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A zero setup masonry image gallery for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/src/get-imgs-list.ts
+++ b/src/get-imgs-list.ts
@@ -21,7 +21,8 @@ const getImagesList = (
   const validExtensions = ["jpeg", "jpg", "gif", "png", "webp", "tiff", "tif"]
   const images = files.filter(file => {
     if ( 
-      ( Boolean(settings.images) ? settings.images.includes(file.name) : true) 
+         ( settings.images.length ? settings.images.includes(file.name) : true) 
+      && ( settings.regex.length  ? settings.regex.some(rgx => rgx.test(file.name)) : true )
       && file instanceof TFile 
       && validExtensions.includes(file.extension)
     ) return file
@@ -29,8 +30,10 @@ const getImagesList = (
 
   let sortedImages
 
-  if (Boolean(settings.images)) {
-    // Explicitly sort the list as-specified in the provided image list
+  if (settings.images.length && !settings.regex.length) {
+    // Explicitly sort the list as-specified in the provided image list,
+    // UNLESS we provided regexes, in which case skip this and do 
+    // normal sorting.
     sortedImages = images.sort((a: any, b: any) => {
       const indexA = settings.images.indexOf(a.name);
       const indexB = settings.images.indexOf(b.name);

--- a/src/get-imgs-list.ts
+++ b/src/get-imgs-list.ts
@@ -20,18 +20,38 @@ const getImagesList = (
   // filter the list of files to make sure we're dealing with images only
   const validExtensions = ["jpeg", "jpg", "gif", "png", "webp", "tiff", "tif"]
   const images = files.filter(file => {
-    if (file instanceof TFile && validExtensions.includes(file.extension)) return file
+    if ( 
+      ( Boolean(settings.images) ? settings.images.includes(file.name) : true) 
+      && file instanceof TFile 
+      && validExtensions.includes(file.extension)
+    ) return file
   })
 
-  // sort the list by name, mtime, or ctime
-  const orderedImages = images.sort((a: any, b: any) => {
-    const refA = settings.sortby === 'name' ? a['name'].toUpperCase() : a.stat[settings.sortby]
-    const refB = settings.sortby === 'name' ? b['name'].toUpperCase() : b.stat[settings.sortby]
-    return (refA < refB) ? -1 : (refA > refB) ? 1 : 0
-  })
+  let sortedImages
 
-  // re-sort again by ascending or descending order
-  const sortedImages = settings.sort === 'asc' ? orderedImages : orderedImages.reverse()
+  if (Boolean(settings.images)) {
+    // Explicitly sort the list as-specified in the provided image list
+    sortedImages = images.sort((a: any, b: any) => {
+      const indexA = settings.images.indexOf(a.name);
+      const indexB = settings.images.indexOf(b.name);
+      
+      // Handle cases where an item might not be in array x
+      if (indexA === -1) return 1;
+      if (indexB === -1) return -1;
+      
+      return indexA - indexB;
+    });
+  } else {
+    // otherwise, sort the list by name, mtime, or ctime
+    const orderedImages = images.sort((a: any, b: any) => {
+      const refA = settings.sortby === 'name' ? a['name'].toUpperCase() : a.stat[settings.sortby]
+      const refB = settings.sortby === 'name' ? b['name'].toUpperCase() : b.stat[settings.sortby]
+      return (refA < refB) ? -1 : (refA > refB) ? 1 : 0
+    })
+
+    // re-sort again by ascending or descending order
+    sortedImages = settings.sort === 'asc' ? orderedImages : orderedImages.reverse()
+  }
 
   // return an array of objects
   return sortedImages.map(file => {

--- a/src/get-imgs-list.ts
+++ b/src/get-imgs-list.ts
@@ -22,7 +22,7 @@ const getImagesList = (
   const images = files.filter(file => {
     if ( 
          ( settings.images.length ? settings.images.includes(file.name) : true) 
-      && ( settings.regex.length  ? settings.regex.some(rgx => rgx.test(file.name)) : true )
+      && ( settings.regex.length  ? settings.regex.some((rgx: RegExp) => rgx.test(file.name)) : true )
       && file instanceof TFile 
       && validExtensions.includes(file.extension)
     ) return file

--- a/src/get-settings.ts
+++ b/src/get-settings.ts
@@ -1,7 +1,8 @@
+import { dirname, normalize, join } from 'path'
 import { normalizePath, parseYaml, Platform } from 'obsidian'
 import renderError from './render-error'
 
-const getSettings = (src: string, container: HTMLElement) => {
+const getSettings = (filePath: string, src: string, container: HTMLElement) => {
   // parse the settings from the code block
   const settingsSrc: any = parseYaml(src)
 
@@ -32,7 +33,14 @@ const getSettings = (src: string, container: HTMLElement) => {
     images: undefined as string[],
   }
 
-  settings.path = normalizePath(settingsSrc.path)
+
+  if (settingsSrc.path.startsWith('./') || settingsSrc.path.startsWith('../')) {
+    settings.path = join(dirname(filePath), settingsSrc.path)
+  } else {
+    settings.path = normalizePath(settingsSrc.path)
+  }
+  settings.path = normalize(settings.path)
+
   settings.type = settingsSrc.type ?? 'horizontal'
   settings.radius = settingsSrc.radius ?? 0
   settings.gutter = settingsSrc.gutter ?? 8

--- a/src/get-settings.ts
+++ b/src/get-settings.ts
@@ -31,6 +31,7 @@ const getSettings = (filePath: string, src: string, container: HTMLElement) => {
     columns: undefined as number,
     height: undefined as number,
     images: undefined as string[],
+    regex: undefined as RegExp[],
   }
 
 
@@ -46,7 +47,8 @@ const getSettings = (filePath: string, src: string, container: HTMLElement) => {
   settings.gutter = settingsSrc.gutter ?? 8
   settings.sortby = settingsSrc.sortby ?? 'ctime'
   settings.sort = settingsSrc.sort ?? 'desc'
-  settings.images = settingsSrc.images ?? false
+  settings.images = settingsSrc.images ?? []
+  settings.regex = settingsSrc.regex ? settingsSrc.regex.map((pattern: string) => new RegExp(pattern)) : []
 
   // settings for vertical mansory only
   settings.mobile = settingsSrc.mobile ?? 1

--- a/src/get-settings.ts
+++ b/src/get-settings.ts
@@ -29,6 +29,7 @@ const getSettings = (src: string, container: HTMLElement) => {
     mobile: undefined as number,
     columns: undefined as number,
     height: undefined as number,
+    images: undefined as string[],
   }
 
   settings.path = normalizePath(settingsSrc.path)
@@ -37,6 +38,7 @@ const getSettings = (src: string, container: HTMLElement) => {
   settings.gutter = settingsSrc.gutter ?? 8
   settings.sortby = settingsSrc.sortby ?? 'ctime'
   settings.sort = settingsSrc.sort ?? 'desc'
+  settings.images = settingsSrc.images ?? false
 
   // settings for vertical mansory only
   settings.mobile = settingsSrc.mobile ?? 1

--- a/src/init.ts
+++ b/src/init.ts
@@ -14,6 +14,7 @@ export class imgGalleryInit extends MarkdownRenderChild {
 
   constructor(
     public plugin: ImgGallery,
+    public filePath: string,
     public src: string,
     public container: HTMLElement,
     public app: App
@@ -23,7 +24,7 @@ export class imgGalleryInit extends MarkdownRenderChild {
 
   async onload() {
     // parse and normalize settings
-    this._settings = getSettings(this.src, this.container)
+    this._settings = getSettings(this.filePath, this.src, this.container)
     this._imagesList = getImagesList(this.app, this.container, this._settings)
 
     // inject the pertinent kind of gallery

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { imgGalleryInit } from './init';
 export default class ImgGallery extends Plugin {
   async onload() {
     this.registerMarkdownCodeBlockProcessor('img-gallery', (src, el, ctx) => {
-      const handler = new imgGalleryInit(this, src, el, this.app)
+      const handler = new imgGalleryInit(this, ctx.sourcePath, src, el, this.app)
       ctx.addChild(handler)
     })
   }


### PR DESCRIPTION
`1.1.2`
  - Changed: "path" setting can now be relative to the current file's directory (prefix with "./").
  - New: "images" setting. Accepts a YAML list of filenames. If this value is provided, only these files will be displayed from the directory. When provided. Overrides any specified sorting order, in favor of the order of the list.
  - New: "regex" setting. Accepts a YAML list of regular expression strings. If this value is provided, only filenames that match AT LEAST ONE of the expressions will be displayed.
